### PR TITLE
adding accessors for config and cb_size_byte

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -325,6 +325,10 @@ impl Config {
         self.cb_max_record_size
     }
 
+    pub fn get_cb_size_byte(&self) -> usize {
+        self.cb_size_byte
+    }
+
     pub fn leaf_page_size(&mut self, leaf_page_size: usize) -> &mut Self {
         self.leaf_page_size = leaf_page_size;
         self

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -386,6 +386,10 @@ impl BfTree {
         })
     }
 
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
     /// Get the buffer metrics of the circular buffer.
     /// This is a blocking call, will stop all other buffer operations,
     /// use it wisely.


### PR DESCRIPTION
This is a small PR where we add accessors for `Config` (in file `tree.rs`) and for `cb_size_byte` (in file `config.rs`). This is to allow saving and loading Bf-Trees in DiskANN library