### PR TITLE
Allow building with newer version of cfg-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4.38", optional = true }
 variant_count = { version = "1.1.0", optional = true }
 toml = "0.8.23"
 thread_local = "1.1.9"
-cfg-if = "=1.0.0"
+cfg-if = "1.0.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.4"


### PR DESCRIPTION
Bf-Tree declares that it is incompatible with 1.0.4 and newer versions of `cfg-if` but it is not clear why this is the case. Possibly https://github.com/rust-lang/cfg-if/issues/90, but that release was yanked within a few minutes and it should not be a reason to use an older version. If there is something that does not work with cfg-if 1.0.4, please add a comment with a link to a cfg-if GitHub issue.