### PR TITLE
Use cqe result to derive error instead of errno

### DIFF
--- a/src/fs/io_uring_vfs.rs
+++ b/src/fs/io_uring_vfs.rs
@@ -171,7 +171,7 @@ impl VfsImpl for IoUringVfs {
                         cqe.result(),
                         buf.len() as i32,
                         "Read cqe result error: {}",
-                        std::io::Error::last_os_error()
+                        std::io::Error::from_raw_os_error(-cqe.result())
                     );
                     break;
                 }
@@ -217,7 +217,7 @@ impl VfsImpl for IoUringVfs {
                         cqe.result(),
                         buf.len() as i32,
                         "Write cqe result error: {}",
-                        std::io::Error::last_os_error()
+                        std::io::Error::from_raw_os_error(-cqe.result())
                     );
                     break;
                 }


### PR DESCRIPTION
Hi, while debugging a failing(`VfsImpl::test_read_write_operations`) test on my SATA SSD, I noticed that the error thrown was `No such file or directory`, which didn't make much sense, looking at the man page of `io_uring`: 
```
Given that io_uring is an async interface,
 errno is never used for passing back error information.
 Instead, res will contain what the equivalent system call
 would have returned in case of success, and in case of
 error res will contain -errno.```
